### PR TITLE
Prompting for notifications permission on Android 13+

### DIFF
--- a/app/src/main/java/uk/ac/york/langtrackapp/screen/main/MainActivity.kt
+++ b/app/src/main/java/uk/ac/york/langtrackapp/screen/main/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
         )
 
         if (ContextCompat.checkSelfPermission(this, POST_NOTIFICATIONS) == PackageManager.PERMISSION_DENIED) {
-            ActivityCompat.requestPermissions(this, arrayOf("POST_NOTIFICATIONS"), 1);
+            ActivityCompat.requestPermissions(this, arrayOf(POST_NOTIFICATIONS), 112);
         }
 
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
Android 13+ has notifications disabled by default, and requires the app to manually prompt the user for the permission. This PR fixes the prompt so that it appears on the main survey page.